### PR TITLE
Strip website tags from body, and prefer second occurence since it ap…

### DIFF
--- a/smsbot/twilio.rb
+++ b/smsbot/twilio.rb
@@ -20,7 +20,8 @@ module SMSBot
         # that occur.
         body.gsub!(/<tel:\+\d+\|(\+\d+)>/, '\1')
         # Strip website tags <http://pirate.com/piratelive@pirate.com/piratelive>
-        body.gsub!(/<http:\/\/[\w\.\/]+\@([\w\.\/]+)>/, '\1')
+        # Strip website tags <http://pirate.com/piratelive|pirate.com/piratelive>
+        body.gsub!(/<http:\/\/[\w\.\/]+[\@|]([\w\.\/]+)>/, '\1')
 
         client.messages.create(
           messaging_service_sid: messaging_service_sid,

--- a/smsbot/twilio.rb
+++ b/smsbot/twilio.rb
@@ -22,6 +22,8 @@ module SMSBot
         # Strip website tags <http://pirate.com/piratelive@pirate.com/piratelive>
         # Strip website tags <http://pirate.com/piratelive|pirate.com/piratelive>
         body.gsub!(/<http:\/\/[\w\.\/]+[\@|]([\w\.\/]+)>/, '\1')
+        # Strip mailto tags <mailto:pete2.black@pirate.co.uk|pete2.black@pirate.co.uk>
+        body.gsub!(/<mailto:[\w\d\.\@]+\|([\w\d\.\@]+)>/, '\1')
 
         client.messages.create(
           messaging_service_sid: messaging_service_sid,

--- a/smsbot/twilio.rb
+++ b/smsbot/twilio.rb
@@ -18,7 +18,9 @@ module SMSBot
         to = to[/(\d+)/]
         # Do the same for the body, stripping as many <tel:+1234|+1234>
         # that occur.
-        body = body.gsub(/<tel:(\+\d+)\|\+\d+>/, '\1')
+        body.gsub!(/<tel:\+\d+\|(\+\d+)>/, '\1')
+        # Strip website tags <http://pirate.com/piratelive@pirate.com/piratelive>
+        body.gsub!(/<http:\/\/[\w\.\/]+\@([\w\.\/]+)>/, '\1')
 
         client.messages.create(
           messaging_service_sid: messaging_service_sid,


### PR DESCRIPTION
…pears to be the user-specified copy.

`@smsbot reply +447967594123 hello +4471346234 www.google.com cats dogs`

was being delivered as:

`hello +4471346234 <http://www.google.com@www.google.com> cats dogs`