### PR TITLE
Decode html entities like &amp; before SMS output. Make "reply" command optional

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ ruby "2.6.3"
 
 gem 'slack-ruby-bot'
 gem 'async-websocket', '~>0.8.0'
+gem 'htmlentities'
 gem 'twilio-ruby'
 gem 'puma'
 gem 'sinatra'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,6 +26,7 @@ GEM
       faraday (>= 0.7.4, < 1.0)
     gli (2.19.0)
     hashie (4.0.0)
+    htmlentities (4.3.4)
     i18n (1.7.0)
       concurrent-ruby (~> 1.0)
     jwt (2.2.1)
@@ -92,6 +93,7 @@ PLATFORMS
 DEPENDENCIES
   async-websocket (~> 0.8.0)
   dotenv
+  htmlentities
   puma
   rack-test
   rspec

--- a/smsbot/commands.rb
+++ b/smsbot/commands.rb
@@ -7,7 +7,15 @@ module SMSBot
         long_desc 'command format: reply +447911111111 Hello there Bobby Tables, how can I help?'
       end
 
-      match /^\p{Z}*(?<bot><\@[\w\d]+>)\p{Z}*(?<command>reply\p{Z}+|send\p{Z}+)?(?<to>\+?[\d]+|<tel:\+?\d+\|\+?\d+>)\p{Z}+(?<message>.*)/ do |client, data, match|
+      match %r{
+          ^\p{Z}*                               # some white space
+          (?<bot><\@[\w\d]+>)                   # bot identifier e.g. <@UQXACP1JT>
+          \p{Z}*                                # optional spaces before command
+          (?<command>reply\p{Z}+|send\p{Z}+)?   # "reply" or "send", but this is now optional, followed by whitespace
+          (?<to>\+?[\d]+|<tel:\+?\d+\|\+?\d+>)  # phone number, either as plain-text or as a <tel:1234|4321>
+          \p{Z}+                                # at least one space
+          (?<message>.+)                        # message of one or more characters
+        }x do |client, data, match|
         #puts "data: #{data.inspect}\n"
 
         #puts "data.text:   #{data.text}"

--- a/smsbot/commands.rb
+++ b/smsbot/commands.rb
@@ -7,7 +7,12 @@ module SMSBot
         long_desc 'command format: reply +447911111111 Hello there Bobby Tables, how can I help?'
       end
 
-      match /(?<command>reply|send)\p{Z}+(?<to>\+?[\d]+|<tel:\+?\d+\|\+?\d+>)\p{Z}+(?<message>.*)/ do |client, data, match|
+      match /^\p{Z}*(?<bot><\@[\w\d]+>)\p{Z}*(?<command>reply\p{Z}+|send\p{Z}+)?(?<to>\+?[\d]+|<tel:\+?\d+\|\+?\d+>)\p{Z}+(?<message>.*)/ do |client, data, match|
+        #puts "data: #{data.inspect}\n"
+
+        #puts "data.text:   #{data.text}"
+        #puts "match:       #{match.inspect}"
+
         begin
           SMSBot::SMS.send(to: match['to'], body: match['message']) do
             client.say(

--- a/smsbot/twilio.rb
+++ b/smsbot/twilio.rb
@@ -37,7 +37,6 @@ module SMSBot
           puts "[body][decode]  '#{body}'"
           coder = HTMLEntities.new
           body = coder.decode(body)
-          puts "[body][decoded] '#{body}'"
         end
         puts "[body][final]   '#{body}'"
         puts ""

--- a/smsbot/twilio.rb
+++ b/smsbot/twilio.rb
@@ -1,4 +1,5 @@
 require 'twilio-ruby'
+require 'htmlentities'
 
 module SMSBot
   class SMS
@@ -15,13 +16,13 @@ module SMSBot
         # Slack started formatting phone numbers with a + prefix as
         # <tel:+447xxxxxxxxx|+447xxxxxxxxx> so use a regex to capture
         # the first set of numbers.
-        puts "[orig]   To: '#{to}'"
+        puts "[to  ][orig]    '#{to}'"
         to = to[/(\d+)/]
-        puts "[parsed] To: '#{to}'"
+        puts "[to  ][parsed]  '#{to}'"
 
         # Do the same for the body, stripping as many <tel:+1234|+1234>
         # that occur.
-        puts "[orig]   Body: '#{body}'"
+        puts "[body][orig]    '#{body}'"
         body.gsub!(/<tel:\+\d+\|(\+\d+)>/, '\1')
         # Strip website tags <http://pirate.com/piratelive@pirate.com/piratelive>
         # Strip website tags <http://pirate.com/piratelive|pirate.com/piratelive>
@@ -30,7 +31,16 @@ module SMSBot
 
         # Strip mailto tags <mailto:pete2.black@pirate.co.uk|pete2.black@pirate.co.uk>
         body.gsub!(/<mailto:[\w\d\.\@]+\|([\w\d\.\@]+)>/, '\1')
-        puts "[parsed] Body: '#{body}'\n"
+
+        # Strip html entities
+        if body.match(/\&\w+;/)
+          puts "[body][decode]  '#{body}'"
+          coder = HTMLEntities.new
+          body = coder.decode(body)
+          puts "[body][decoded] '#{body}'"
+        end
+        puts "[body][final]   '#{body}'"
+        puts ""
 
         client.messages.create(
           messaging_service_sid: messaging_service_sid,


### PR DESCRIPTION
Decode html entities like &amp; before SMS output.
Make "reply" command optional.
Describe match regex expression over multiple lines so it doesn't get too unwieldy.